### PR TITLE
Use `ViewerModel` instead of `make_napari_viewer` in `test_toggle_axes_scale_bar_attr`

### DIFF
--- a/napari/_app_model/_app.py
+++ b/napari/_app_model/_app.py
@@ -8,6 +8,7 @@ from napari._app_model.actions._layerlist_context_actions import (
     LAYERLIST_CONTEXT_ACTIONS,
     LAYERLIST_CONTEXT_SUBMENUS,
 )
+from napari._app_model.actions._view import VIEW_ACTIONS
 
 APP_NAME = 'napari'
 
@@ -34,6 +35,7 @@ class NapariApplication(Application):
         self.injection_store.namespace = _napari_names  # type: ignore [assignment]
 
         self.register_actions(LAYERLIST_CONTEXT_ACTIONS)
+        self.register_actions(VIEW_ACTIONS)
         self.menus.append_menu_items(LAYERLIST_CONTEXT_SUBMENUS)
 
     @classmethod

--- a/napari/_app_model/actions/_toggle_action.py
+++ b/napari/_app_model/actions/_toggle_action.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from typing import Any
+
+from app_model import Action
+from app_model.types import ToggleRule
+
+from napari.components import ViewerModel
+
+
+class ViewerModelToggleAction(Action):
+    """Action subclass that toggles a boolean viewer (sub)attribute on trigger.
+
+    Parameters
+    ----------
+    id : str
+        The command id of the action.
+    title : str
+        The title of the action. Prefer capital case.
+    viewer_attribute : str
+        The attribute of the viewer to toggle. (e.g. 'axes')
+    sub_attribute : str
+        The attribute of the viewer attribute to toggle. (e.g. 'visible')
+    **kwargs
+        Additional keyword arguments to pass to the Action constructor.
+
+    Examples
+    --------
+    >>> action = ViewerModelToggleAction(
+    ...     id='some.command.id',
+    ...     title='Toggle Axis Visibility',
+    ...     viewer_attribute='axes',
+    ...     sub_attribute='visible',
+    ... )
+    """
+
+    def __init__(
+        self,
+        *,
+        id: str,  # noqa: A002
+        title: str,
+        viewer_attribute: str,
+        sub_attribute: str,
+        **kwargs: Any,
+    ) -> None:
+        def get_current(viewer: ViewerModel) -> bool:
+            """return the current value of the viewer attribute"""
+            attr = getattr(viewer, viewer_attribute)
+            return getattr(attr, sub_attribute)
+
+        def toggle(viewer: ViewerModel) -> None:
+            """toggle the viewer attribute"""
+            attr = getattr(viewer, viewer_attribute)
+            setattr(attr, sub_attribute, not getattr(attr, sub_attribute))
+
+        super().__init__(
+            id=id,
+            title=title,
+            toggled=ToggleRule(get_current=get_current),
+            callback=toggle,
+            **kwargs,
+        )

--- a/napari/_app_model/actions/_view.py
+++ b/napari/_app_model/actions/_view.py
@@ -1,0 +1,75 @@
+from napari._app_model.actions._toggle_action import ViewerModelToggleAction
+from napari._app_model.constants import MenuId
+from napari.utils.translations import trans
+
+toggle_action_details = [
+    (
+        'napari.window.view.toggle_viewer_axes',
+        trans._('Axes Visible'),
+        'axes',
+        'visible',
+    ),
+    (
+        'napari.window.view.toggle_viewer_axes_colored',
+        trans._('Axes Colored'),
+        'axes',
+        'colored',
+    ),
+    (
+        'napari.window.view.toggle_viewer_axes_labels',
+        trans._('Axes Labels'),
+        'axes',
+        'labels',
+    ),
+    (
+        'napari.window.view.toggle_viewer_axesdashed',
+        trans._('Axes Dashed'),
+        'axes',
+        'dashed',
+    ),
+    (
+        'napari.window.view.toggle_viewer_axes_arrows',
+        trans._('Axes Arrows'),
+        'axes',
+        'arrows',
+    ),
+    (
+        'napari.window.view.toggle_viewer_scale_bar',
+        trans._('Scale Bar Visible'),
+        'scale_bar',
+        'visible',
+    ),
+    (
+        'napari.window.view.toggle_viewer_scale_bar_box',
+        trans._('Scale Bar Box'),
+        'scale_bar',
+        'box',
+    ),
+    (
+        'napari.window.view.toggle_viewer_scale_bar_colored',
+        trans._('Scale Bar Colored'),
+        'scale_bar',
+        'colored',
+    ),
+    (
+        'napari.window.view.toggle_viewer_scale_bar_ticks',
+        trans._('Scale Bar Ticks'),
+        'scale_bar',
+        'ticks',
+    ),
+]
+
+VIEW_ACTIONS = []
+MENUID_DICT = {'axes': MenuId.VIEW_AXES, 'scale_bar': MenuId.VIEW_SCALEBAR}
+
+
+for cmd, cmd_title, viewer_attr, sub_attr in toggle_action_details:
+    VIEW_ACTIONS.append(
+        ViewerModelToggleAction(
+            id=cmd,
+            title=cmd_title,
+            viewer_attribute=viewer_attr,
+            sub_attribute=sub_attr,
+            menus=[{'id': MENUID_DICT[viewer_attr]}],
+        )
+    )

--- a/napari/_qt/_qapp_model/_tests/test_togglers.py
+++ b/napari/_qt/_qapp_model/_tests/test_togglers.py
@@ -1,16 +1,18 @@
-from napari import Viewer
+import pytest
+
 from napari._app_model._app import get_app_model
+from napari._app_model.actions._toggle_action import ViewerModelToggleAction
 from napari._qt._qapp_model.qactions._toggle_action import (
     DockWidgetToggleAction,
-    ViewerToggleAction,
 )
 from napari._qt.qt_main_window import Window
 from napari.components import ViewerModel
 
 
-def test_viewer_toggler(mock_app_model):
+@pytest.mark.usefixtures('mock_app_model')
+def test_viewer_toggler():
     viewer = ViewerModel()
-    action = ViewerToggleAction(
+    action = ViewerModelToggleAction(
         id='some.command.id',
         title='Toggle Axis Visibility',
         viewer_attribute='axes',
@@ -23,7 +25,7 @@ def test_viewer_toggler(mock_app_model):
     # so this provider is used over `_provide_viewer`, which would raise an error
     with app.injection_store.register(
         providers=[
-            (lambda: viewer, Viewer, 100),
+            (lambda: viewer, ViewerModel, 100),
         ]
     ):
         assert viewer.axes.visible is False

--- a/napari/_qt/_qapp_model/_tests/test_view_menu.py
+++ b/napari/_qt/_qapp_model/_tests/test_view_menu.py
@@ -7,10 +7,10 @@ from qtpy.QtCore import QPoint, Qt
 from qtpy.QtWidgets import QApplication
 
 from napari._app_model import get_app_model
+from napari._app_model.actions._view import toggle_action_details
 from napari._qt._qapp_model.qactions._view import (
     _get_current_tooltip_visibility,
     _toggle_canvas_ndim,
-    toggle_action_details,
 )
 from napari._tests.utils import skip_local_focus, skip_local_popups
 from napari.viewer import ViewerModel
@@ -46,7 +46,7 @@ def check_view_menu_visibility(viewer, qtbot):
     toggle_action_details,
 )
 def test_toggle_axes_scale_bar_attr(
-    make_napari_viewer, action_id, action_title, viewer_attr, sub_attr
+    action_id, action_title, viewer_attr, sub_attr
 ):
     """
     Test toggle actions related with viewer axes and scale bar attributes.
@@ -64,7 +64,7 @@ def test_toggle_axes_scale_bar_attr(
         * `ticks`
     """
     app = get_app_model()
-    viewer = make_napari_viewer()
+    viewer = ViewerModel()
 
     # Get viewer attribute to check (`axes` or `scale_bar`)
     axes_scale_bar = getattr(viewer, viewer_attr)
@@ -73,7 +73,8 @@ def test_toggle_axes_scale_bar_attr(
     initial_value = getattr(axes_scale_bar, sub_attr)
 
     # Change sub-attribute via action command execution and check value
-    app.commands.execute_command(action_id)
+    with app.injection_store.register(providers={ViewerModel: viewer}):
+        app.commands.execute_command(action_id)
     changed_value = getattr(axes_scale_bar, sub_attr)
     assert initial_value is not changed_value
 

--- a/napari/_qt/_qapp_model/qactions/_toggle_action.py
+++ b/napari/_qt/_qapp_model/qactions/_toggle_action.py
@@ -1,67 +1,10 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from app_model.types import Action, ToggleRule
 
 from napari._qt.qt_main_window import Window
-
-if TYPE_CHECKING:
-    from napari.viewer import Viewer
-
-
-class ViewerToggleAction(Action):
-    """Action subclass that toggles a boolean viewer (sub)attribute on trigger.
-
-    Parameters
-    ----------
-    id : str
-        The command id of the action.
-    title : str
-        The title of the action. Prefer capital case.
-    viewer_attribute : str
-        The attribute of the viewer to toggle. (e.g. 'axes')
-    sub_attribute : str
-        The attribute of the viewer attribute to toggle. (e.g. 'visible')
-    **kwargs
-        Additional keyword arguments to pass to the Action constructor.
-
-    Examples
-    --------
-    >>> action = ViewerToggleAction(
-    ...     id='some.command.id',
-    ...     title='Toggle Axis Visibility',
-    ...     viewer_attribute='axes',
-    ...     sub_attribute='visible',
-    ... )
-    """
-
-    def __init__(
-        self,
-        *,
-        id: str,  # noqa: A002
-        title: str,
-        viewer_attribute: str,
-        sub_attribute: str,
-        **kwargs: Any,
-    ) -> None:
-        def get_current(viewer: Viewer) -> bool:
-            """return the current value of the viewer attribute"""
-            attr = getattr(viewer, viewer_attribute)
-            return getattr(attr, sub_attribute)
-
-        def toggle(viewer: Viewer) -> None:
-            """toggle the viewer attribute"""
-            attr = getattr(viewer, viewer_attribute)
-            setattr(attr, sub_attribute, not getattr(attr, sub_attribute))
-
-        super().__init__(
-            id=id,
-            title=title,
-            toggled=ToggleRule(get_current=get_current),
-            callback=toggle,
-            **kwargs,
-        )
 
 
 class DockWidgetToggleAction(Action):

--- a/napari/_qt/_qapp_model/qactions/_view.py
+++ b/napari/_qt/_qapp_model/qactions/_view.py
@@ -12,7 +12,6 @@ from app_model.types import (
 )
 
 from napari._app_model.constants import MenuGroup, MenuId
-from napari._qt._qapp_model.qactions._toggle_action import ViewerToggleAction
 from napari._qt.qt_main_window import Window
 from napari._qt.qt_viewer import QtViewer
 from napari.settings import get_settings
@@ -225,76 +224,3 @@ Q_VIEW_ACTIONS: list[Action] = [
         toggled=ToggleRule(get_current=_get_current_tooltip_visibility),
     ),
 ]
-
-MENUID_DICT = {'axes': MenuId.VIEW_AXES, 'scale_bar': MenuId.VIEW_SCALEBAR}
-
-toggle_action_details = [
-    (
-        'napari.window.view.toggle_viewer_axes',
-        trans._('Axes Visible'),
-        'axes',
-        'visible',
-    ),
-    (
-        'napari.window.view.toggle_viewer_axes_colored',
-        trans._('Axes Colored'),
-        'axes',
-        'colored',
-    ),
-    (
-        'napari.window.view.toggle_viewer_axes_labels',
-        trans._('Axes Labels'),
-        'axes',
-        'labels',
-    ),
-    (
-        'napari.window.view.toggle_viewer_axesdashed',
-        trans._('Axes Dashed'),
-        'axes',
-        'dashed',
-    ),
-    (
-        'napari.window.view.toggle_viewer_axes_arrows',
-        trans._('Axes Arrows'),
-        'axes',
-        'arrows',
-    ),
-    (
-        'napari.window.view.toggle_viewer_scale_bar',
-        trans._('Scale Bar Visible'),
-        'scale_bar',
-        'visible',
-    ),
-    (
-        'napari.window.view.toggle_viewer_scale_bar_box',
-        trans._('Scale Bar Box'),
-        'scale_bar',
-        'box',
-    ),
-    (
-        'napari.window.view.toggle_viewer_scale_bar_colored',
-        trans._('Scale Bar Colored'),
-        'scale_bar',
-        'colored',
-    ),
-    (
-        'napari.window.view.toggle_viewer_scale_bar_ticks',
-        trans._('Scale Bar Ticks'),
-        'scale_bar',
-        'ticks',
-    ),
-]
-
-# Add `Action`s that toggle various viewer `axes` and `scale_bar` sub-attributes
-# E.g., `toggle_viewer_scale_bar_ticks` toggles the sub-attribute `ticks` of the
-# viewer attribute `scale_bar`
-for cmd, cmd_title, viewer_attr, sub_attr in toggle_action_details:
-    Q_VIEW_ACTIONS.append(
-        ViewerToggleAction(
-            id=cmd,
-            title=cmd_title,
-            viewer_attribute=viewer_attr,
-            sub_attribute=sub_attr,
-            menus=[{'id': MENUID_DICT[viewer_attr]}],
-        )
-    )


### PR DESCRIPTION
Recreated from original PR: https://github.com/napari/napari/pull/7885

# References and relevant issues

extracted from #7803

# Description

As the test is not checking the state of qt elements, it is enough to use `ViewerModel` instead of viewer.  
